### PR TITLE
Update solution and projects to .NET 8

### DIFF
--- a/SlimDHT.sln
+++ b/SlimDHT.sln
@@ -1,13 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35828.75 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimDHT", "SlimDHT\SlimDHT.csproj", "{34952BFC-1A9B-472A-829E-0CE66F1AD643}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeanIPC", "..\..\Udvikler\LeanIPC\LeanIPC\LeanIPC.csproj", "{E23C0FCF-E57E-4A08-8EF0-637EE231CE63}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoCoL-NetStd20", "..\..\Udvikler\CoCoL\src\CoCoL-NetStd20\CoCoL-NetStd20.csproj", "{ADDD6F1E-5EE7-443B-BFFC-EEE9F165D8C1}"
-EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "Unittest", "Unittest\Unittest.csproj", "{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unittest", "Unittest\Unittest.csproj", "{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,17 +16,15 @@ Global
 		{34952BFC-1A9B-472A-829E-0CE66F1AD643}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34952BFC-1A9B-472A-829E-0CE66F1AD643}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34952BFC-1A9B-472A-829E-0CE66F1AD643}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E23C0FCF-E57E-4A08-8EF0-637EE231CE63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E23C0FCF-E57E-4A08-8EF0-637EE231CE63}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E23C0FCF-E57E-4A08-8EF0-637EE231CE63}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E23C0FCF-E57E-4A08-8EF0-637EE231CE63}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ADDD6F1E-5EE7-443B-BFFC-EEE9F165D8C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADDD6F1E-5EE7-443B-BFFC-EEE9F165D8C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ADDD6F1E-5EE7-443B-BFFC-EEE9F165D8C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ADDD6F1E-5EE7-443B-BFFC-EEE9F165D8C1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1DDB731-B8B8-41B2-8FD3-9CA6064FC9CC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6D1C577F-C024-40CD-A59A-A81C69E7F98F}
 	EndGlobalSection
 EndGlobal

--- a/SlimDHT/SlimDHT.csproj
+++ b/SlimDHT/SlimDHT.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Udvikler\CoCoL\src\CoCoL-NetStd20\CoCoL-NetStd20.csproj" />
-    <ProjectReference Include="..\..\..\Udvikler\LeanIPC\LeanIPC\LeanIPC.csproj" />
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="CoCoL" Version="1.8.1" />
+    <PackageReference Include="LeanIPC" Version="0.9.1" />
     <PackageReference Include="log4net" Version="2.0.17" />
   </ItemGroup>
   <ItemGroup>

--- a/Unittest/Unittest.csproj
+++ b/Unittest/Unittest.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SlimDHT\SlimDHT.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Removed the `LeanIPC` and `CoCoL-NetStd20` projects from `SlimDHT.sln`.
- Changed the target framework of `SlimDHT.csproj` from `netcoreapp2.0` to `net8.0` with nugets package references for `CoCoL` and `LeanIPC`.